### PR TITLE
fix: simplify ayingott visual treatment

### DIFF
--- a/app/components/site/AppHeader.vue
+++ b/app/components/site/AppHeader.vue
@@ -24,7 +24,7 @@ function isActive(to: string) {
             v-for="item in navItems"
             :key="item.to"
             :to="item.to"
-            class="site-header__link focus-ring"
+            class="site-header__link"
             :class="{ 'site-header__link--active': isActive(item.to) }"
             :aria-current="isActive(item.to) ? 'page' : undefined"
           >

--- a/app/components/site/SiteIconLink.vue
+++ b/app/components/site/SiteIconLink.vue
@@ -13,7 +13,7 @@ defineProps<{
   <NuxtLink
     :to="href"
     :aria-label="label"
-    class="site-icon-link touch-target focus-ring"
+    class="site-icon-link touch-target"
     :target="external ? '_blank' : undefined"
     :rel="external ? 'noopener noreferrer' : undefined"
   >

--- a/app/components/theme/toggle.vue
+++ b/app/components/theme/toggle.vue
@@ -13,7 +13,7 @@ function toggleDark() {
 <template>
   <button
     type="button"
-    class="theme-toggle touch-target focus-ring"
+    class="theme-toggle touch-target"
     :aria-label="toggleLabel"
     :aria-pressed="isDark"
     :title="toggleLabel"

--- a/app/error.vue
+++ b/app/error.vue
@@ -32,7 +32,7 @@ function goHome() {
 
       <button
         type="button"
-        class="error-page__button touch-target focus-ring"
+        class="error-page__button touch-target"
         @click="goHome"
       >
         回到首页

--- a/app/pages/blog/[slug].vue
+++ b/app/pages/blog/[slug].vue
@@ -24,9 +24,7 @@ useSiteSeo({
 
 <template>
   <article class="blog-detail">
-    <NuxtLink class="blog-detail__back focus-ring" to="/blog">
-      ← 文章
-    </NuxtLink>
+    <NuxtLink class="blog-detail__back" to="/blog">← 文章</NuxtLink>
 
     <header class="blog-detail__header">
       <p class="blog-detail__meta">{{ post.date }} · {{ post.readingTime }}</p>

--- a/app/pages/blog/index.vue
+++ b/app/pages/blog/index.vue
@@ -23,7 +23,7 @@ useSiteSeo({
 
     <div v-if="posts.length" class="blog-page__list" aria-label="文章">
       <article v-for="post in posts" :key="post.slug" class="blog-card">
-        <NuxtLink class="blog-card__link focus-ring" :to="`/blog/${post.slug}`">
+        <NuxtLink class="blog-card__link" :to="`/blog/${post.slug}`">
           <span class="blog-card__meta">
             {{ post.date }} · {{ post.readingTime }}
           </span>

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import ContactStrip from "~/components/site/ContactStrip.vue"
-import DecorativePrimitive from "~/components/site/DecorativePrimitive.vue"
 
 definePageMeta({
   layout: "home",
@@ -19,11 +18,6 @@ useSiteSeo({
 <template>
   <section class="home-page" aria-labelledby="home-title">
     <div class="home-page__copy">
-      <div class="home-page__decoration">
-        <DecorativePrimitive kind="dot" />
-        <DecorativePrimitive kind="line" />
-      </div>
-
       <p class="home-page__eyebrow">ayingott.me</p>
       <h1 id="home-title" class="home-page__title">
         Hi, I'm {{ identity.displayName }}.
@@ -49,7 +43,7 @@ useSiteSeo({
 
 <style scoped>
 .home-page {
-  width: min(100%, var(--container-wide));
+  width: min(100%, var(--container-reading));
   min-height: calc(100svh - 160px);
   margin-inline: auto;
   display: flex;
@@ -61,15 +55,6 @@ useSiteSeo({
 .home-page__copy {
   position: relative;
   max-width: 640px;
-}
-
-.home-page__decoration {
-  position: absolute;
-  top: var(--spacing-2);
-  right: 0;
-  display: flex;
-  align-items: center;
-  gap: var(--spacing-3);
 }
 
 .home-page__eyebrow {
@@ -131,11 +116,6 @@ useSiteSeo({
   .home-page {
     min-height: auto;
     padding-block: var(--spacing-8);
-  }
-
-  .home-page__decoration {
-    position: static;
-    margin-bottom: var(--spacing-6);
   }
 
   .home-page__title {


### PR DESCRIPTION
## Summary
- remove always-on `focus-ring` utility classes from interactive elements so default nav/buttons/icons no longer render persistent outlines
- constrain the home hero to `--container-reading` to remove the left-heavy wide-frame layout
- remove the orphan home dot/line decoration while preserving anchored decorations on other pages

## Verification
- `pnpm lint`
- `pnpm generate` (known Nuxt/Tailwind sourcemap warnings only)
- `git diff --check`
- generated output check: no `focus-ring` class references under `app/`, home CSS uses `--container-reading`, home decoration CSS/markup removed
- Playwright MCP static smoke at `http://127.0.0.1:3009/`: desktop 1440px + mobile 375px home screenshots; no persistent focus border/box-shadow visible, home content no longer left-cramped, no home dot/line decoration