### PR TITLE
docs(ux): update §5 decoration rules after PR #10 visual escape

### DIFF
--- a/docs/ux/design-v0.1.md
+++ b/docs/ux/design-v0.1.md
@@ -516,7 +516,7 @@ The prompt format:
 
 Run them in order. After each, paste the output into this thread; UX runs critique loop and converges to a TL-implementable mockup.
 
-**Historical note**: the prompts below were the V1 mockup-generation set, run once on 2026-05-08 and the resulting mockup was approved as the S2 implementation baseline. They render nav and chrome as English (`Home / About / Blog / Not found. / Back to home / etc.`) because that was the working assumption at prompt-generation time. The locked rendered values for V1 are Chinese per §2.1; the implementation uses §2.1 as the authoritative source, not these prompts. Re-running these prompts to regenerate mockups would require updating each prompt's nav and chrome strings to the §2.1 Chinese values.
+**Historical note**: the prompts below were the V1 mockup-generation set, run once on 2026-05-08 and the resulting mockup was approved as the S2 implementation baseline. They render nav and chrome as English (`Home / About / Blog / Not found. / Back to home / etc.`) because that was the working assumption at prompt-generation time. The locked rendered values for V1 are Chinese per §2.1; the implementation uses §2.1 as the authoritative source, not these prompts. Re-running these prompts to regenerate mockups would require updating each prompt's nav and chrome strings to the §2.1 Chinese values. Home decoration follows §4.1 / §5: no primitive on the home hero.
 
 ### 7.1 Prompt 1 · Home page
 
@@ -560,8 +560,8 @@ Constraints:
 - No gradients, no images, no patterns, no textures.
 - No icon fonts; icons are inline SVGs in monoline 1.5px stroke style.
 - No exclamation points. No "Welcome!" copy.
-- Place exactly one dot + line decoration combo in the top-right margin
-  of the signature block. Lavender, sparse.
+- Do not place a decoration primitive on the home hero / signature block.
+  The signature block carries the page on its own; keep it quiet.
 - Provide both light and dark variants. Dark canvas is purple-tinged
   near-black (#121019), not neutral grey.
 ```

--- a/docs/ux/design-v0.1.md
+++ b/docs/ux/design-v0.1.md
@@ -220,7 +220,7 @@ Each block lists its semantic vars, spacing, and accessibility role. Anything no
 
 **Decoration**:
 
-- Place 1 dot (8px) and 1 line (40×2) primitive at the top-right of the signature block. Color `var(--accent-primary)`. See §5.
+- The Home page renders **without a decoration primitive**. The signature block (`Hi, I'm Lo.` + tagline) is the page's strongest visual anchor on its own; in production the original spec's "dot + line at the top-right of the signature block" recipe ended up reading as a detached ornament rather than a section accent and was removed in PR #10 (`f83caae`). The lesson is captured in §5: decoration belongs in chrome that has a clear anchor (a heading the visitor reads as a "page title"); the home hero is not that anchor.
 
 **Conditional rendering**:
 
@@ -436,15 +436,17 @@ The four geometric primitives from `@ayingott/theme` spec §5.3 (8×8 dot, 40×2
 
 **Where to place**:
 
-- Top-right margin of page title blocks (Home signature, About title, Blog list title). One primitive, never two.
+- Top-right margin of **page title blocks that read as section titles** — About title, Blog list title. The home signature block is **excluded** from this rule (PR #10 finding): without a section-title anchor the dot + line floated as an orphan and read as ornament rather than rhythm. One primitive per anchored block, never two.
+- Adjacent to a single primary mark — under the 404 digit (line), inside the blog list empty state (square next to the heading). The decoration is acting as a quiet visual punctuation for the primary mark, not as ornament added afterward.
 - Visual rhythm between long lists (every Nth row, where N ≥ 3). Centered horizontally, dot or line only.
-- 404 page under the digit, line only.
+- 404 page under the digit, line only (already covered by the "primary mark" rule above; listed explicitly because it is the most identity-carrying use of the line primitive).
 
 **Where not to place**:
 
 - Inside body prose. Decoration belongs to layout chrome, not reading flow.
 - Inside cards. Cards have their own visual weight from shadow and border; adding decoration overloads them.
 - Full-bleed pattern fills. The motif is sparse seasoning, never pattern.
+- **The home hero / signature block.** The Home page (§4.1) reads correctly without decoration; adding a primitive that does not visually attach to the H1 (`Hi, I'm Lo.`) ends up as floating ornament. Documented in PR #10 visual escape; restored only if the home gains a clear anchored section title in a later iteration.
 
 **Color and inheritance**:
 


### PR DESCRIPTION
## Summary

Update `docs/ux/design-v0.1.md` §4.1 and §5 to reflect the home-decoration removal landed in PR #10 (`f83caae`), so the spec stops directing future implementers to put a dot + line at the top-right of the home signature block.

## What changed

- **§4.1 Home / Decoration**: replaced the "1 dot + 1 line at the top-right of the signature block" instruction with a paragraph that explains the home renders without a primitive and why (signature is not a section-title anchor; orphan ornament was the visual escape lo-user reported).
- **§5 Decoration placement rules / Where to place**: dropped "Home signature" from the anchored-title list, added a "primary mark" anchor pattern (covering the 404 digit and the blog empty-state heading). Cleaned up the older 404-only bullet so it cross-references the primary-mark pattern instead of standing alone.
- **§5 Where not to place**: added an explicit exclusion for the home hero / signature block so the orphan ornament does not re-enter the implementation.

## Why

PR #10 visual fix removed the home dot + line because it read as detached ornament on real desktop renders. Without this spec patch, a future implementer reading the doc would re-introduce it from §4.1 and §5. This brings the canonical UX contract in line with the merged code.

## Verification

- `pnpm lint` clean (lint-staged ran prettier on commit).
- Doc-only PR; no token / structural changes.
- Implementation already matches the new guidance (no follow-up code work needed).

## Linked

- Fixes the spec drift left by PR #10 visual escape.
- Pairs with the longer-term V0 `focus-ring` utility patch tracked separately in `LoTwT/design-system` (V0.0.2 candidate).