### PR TITLE
feat(home): add static Lo signature mark to home header

### DIFF
--- a/app/components/site/AppHeader.vue
+++ b/app/components/site/AppHeader.vue
@@ -4,7 +4,6 @@ import ThemeToggle from "~/components/theme/toggle.vue"
 
 const route = useRoute()
 const { navItems } = useSiteContent()
-const showHeaderMark = computed(() => route.path !== "/")
 
 function isActive(to: string) {
   if (to === "/") {
@@ -17,16 +16,8 @@ function isActive(to: string) {
 
 <template>
   <header class="site-header">
-    <div
-      class="site-header__inner"
-      :class="{ 'site-header__inner--markless': !showHeaderMark }"
-    >
-      <NuxtLink
-        v-if="showHeaderMark"
-        to="/"
-        class="site-header__mark"
-        aria-label="Lo"
-      >
+    <div class="site-header__inner">
+      <NuxtLink to="/" class="site-header__mark" aria-label="Lo">
         <LoSignatureMark :animated="false" />
       </NuxtLink>
 
@@ -69,10 +60,6 @@ function isActive(to: string) {
   align-items: center;
   justify-content: space-between;
   gap: var(--spacing-4);
-}
-
-.site-header__inner--markless {
-  justify-content: flex-end;
 }
 
 .site-header__mark {

--- a/docs/ux/design-v0.1.md
+++ b/docs/ux/design-v0.1.md
@@ -159,9 +159,9 @@ Blog posts additionally publish (Open Graph article properties; use `property=`,
 - Canonical paths are lowercase with trailing slash dropped. `/blog/post-slug`, not `/Blog/Post-Slug/`.
 - 404 catches everything not enumerated above. There is no 410 / gone handling for V1.
 
-### 3.5 Header behavior (Q3 hybrid signature mark)
+### 3.5 Header behavior (uniform static signature mark, all pages)
 
-The site header is sticky and behaves differently between **home** and **inner pages** (about / blog list / blog detail / 404). This is the Q3=B "hybrid header" outcome from design loop v2 (lo-user msg `b06a1f40`).
+The site header is sticky and **carries the same static cursive Lo signature mark across all pages** (home / about / blog list / blog detail / 404). This is the v14 update of the original Q3 hybrid (lo-user msg `74f99bc1`, 2026-05-10): home was previously markless, but lo-user requested the home header carry the mark too — to provide a consistent chrome-level brand anchor on every page.
 
 **Sticky chrome (all pages)**:
 
@@ -170,17 +170,19 @@ The site header is sticky and behaves differently between **home** and **inner p
 - `background: var(--surface-canvas)` so content scrolls beneath without bleeding through.
 - Padding: `var(--layout-page-gutter)`.
 
-**Left-side mark (route-conditional)**:
+**Left-side mark (uniform, all pages)**:
 
-- **Home (`/`)**: header has **no left-side mark**. The hero already carries the animated Lo signature; placing a second mark in the header would double-anchor identity in the same viewport. The header inner row uses `justify-content: flex-end` so the nav cluster sits flush right.
-- **Inner pages (about / blog / 404 / etc.)**: header carries a **static cursive Lo signature mark** as a brand anchor and home-link target.
-  - Component: `<LoSignatureMark :animated="false" />` (static variant, see §4.7 contract).
-  - Size: `--lo-signature-width: 54px; --lo-signature-height: 36px; --lo-signature-stroke-width: 0.32;`.
-  - Wrapper: `<NuxtLink to="/" aria-label="Lo">` with `min-width / min-height: var(--touch-target-min)` (44px) so the visible 54×36 mark sits in a ≥ 44×44 hit area.
-  - Hover: color shifts to `var(--text-accent)`.
-- **Right cluster (all pages)**: nav links + theme toggle. Nav links are `var(--font-mono)` at **`var(--text-sm)` (14px)**, `padding-block: var(--spacing-2)`, `padding-inline: var(--spacing-3)`, `border-radius: var(--radius-control)`, `transition: var(--transition-interactive)`. Each nav link has a ≥ 44×44 hit area via the V0 `touch-target` utility. The active link uses `var(--text-accent)`; siblings use `var(--text-primary)`.
+- All pages render a **static cursive Lo signature mark** as a brand anchor and home-link target.
+- Component: `<LoSignatureMark :animated="false" />` (static variant, see §4.7 contract).
+- Size: `--lo-signature-width: 54px; --lo-signature-height: 36px; --lo-signature-stroke-width: 0.32;`.
+- Wrapper: `<NuxtLink to="/" aria-label="Lo">` with `min-width / min-height: var(--touch-target-min)` (44px) so the visible 54×36 mark sits in a ≥ 44×44 hit area.
+- Hover: color shifts to `var(--text-accent)`.
 
-**Why a static (not animated) mark on inner pages**: the animated 12s cycle in the chrome region pulls attention from the page content. Inner pages are reading surfaces; the brand anchor should be present but quiet. The static cursive Lo (filled glyph, no stroke animation) preserves brand recognition without competing with content.
+**Right cluster (all pages)**: nav links + theme toggle. Nav links are `var(--font-mono)` at **`var(--text-sm)` (14px)**, `padding-block: var(--spacing-2)`, `padding-inline: var(--spacing-3)`, `border-radius: var(--radius-control)`, `transition: var(--transition-interactive)`. Each nav link has a ≥ 44×44 hit area via the V0 `touch-target` utility. The active link uses `var(--text-accent)`; siblings use `var(--text-primary)`.
+
+**Home double-mark visual relationship**: home renders both a **small static mark in the header (54×36)** and a **large animated signature in the hero (~76×51)** — these are intentionally not the same visual weight. The chrome mark is a quiet brand anchor; the hero signature is the page's primary identity moment. The cursive Lo path data is shared, so the two marks read as consistent siblings rather than duplicate elements (small printed stamp + large hand signature).
+
+**Why a static (not animated) mark on chrome**: the animated 12s cycle in the chrome region would pull attention from page content on every page. Static filled cursive Lo preserves brand recognition without competing for attention. Hero animation is reserved for the home identity moment only.
 
 **Reduced-motion**: the static variant is already animation-free, so `prefers-reduced-motion: reduce` is a no-op for the header mark.
 
@@ -215,14 +217,14 @@ Each block lists its semantic vars, spacing, and accessibility role. Anything no
 
 **Purpose**: identity card. The visitor lands and within one screen knows who this is and where to go next.
 
-**Block layout (top to bottom, V1 design loop v2 contract)**:
+**Block layout (top to bottom, v14 update — home now also carries chrome mark)**:
 
 ```
 ┌─────────────────────────────────────────────────────┐
-│  Header (sticky, no left mark on home)              │
-│  ┌──────────────────┐                               │
-│  │ Nav · Theme tog. │                               │
-│  └──────────────────┘                               │
+│  Header (sticky, static Lo mark left + nav right)   │
+│  ┌────────┐                  ┌──────────────────┐   │
+│  │ Lo mark│                  │ Nav · Theme tog. │   │
+│  └────────┘                  └──────────────────┘   │
 │                                                     │
 │  Hero signature block (centered)                    │
 │  ┌─────────────────────────────────────────────┐    │


### PR DESCRIPTION
## Summary

v14-C1 per lo-user msg `74f99bc1`: home header now carries the same static cursive Lo mark as inner pages, providing a consistent chrome-level brand anchor across the entire site.

## What changed

**Runtime (`app/components/site/AppHeader.vue`)**
- Drop the `showHeaderMark = route.path !== "/"` route gating; render `<LoSignatureMark :animated="false" />` on every page including home.
- Remove the obsolete `site-header__inner--markless` variant CSS (no longer reachable now that all routes show the mark).

**Spec (`docs/ux/design-v0.1.md`)**
- §3.5 renamed from "Q3 hybrid signature mark" → "uniform static signature mark, all pages"; add a home-specific note explaining the chrome mark + hero signature visual hierarchy (small static stamp + large animated signature share path data; complementary not duplicate).
- §4.1 block layout diagram updated to show the home header now carries the static mark on the left.

## Why

lo-user 2026-05-10 `74f99bc1`: "首页左上角也加个静态的 svg 吧" — the v13 Q3=B "home empty + inner pages mark" hybrid felt asymmetric; uniform mark gives consistent identity across all routes.

UX evaluation in thread (`#ayingott-me` msg `265715ca`): static 54×36 chrome mark + 76×51 hero animated signature read as "small printed stamp + large hand signature" — same path data, different sizes + behaviors, not visual duplication.

## Test plan

- [ ] `pnpm lint`
- [ ] `pnpm generate`
- [ ] `git diff --check`
- [ ] HTTP smoke: `/`, `/about`, `/blog`, `/404` all 200
- [ ] Browser: home header now shows static cursive Lo mark on the left; clicking it navigates to `/` (since we're already on `/`, it's a no-op nav, focus stays); inner pages unchanged.
- [ ] Sticky header behavior unchanged across all pages.
- [ ] H1 hero signature animation unchanged (still 12s 5-phase cycle).
- [ ] reduced-motion: header mark stays static (no-op since static variant has no animation).

## Slock context

- Owner: @UX (spec + patch)
- Task: v14-C1 home static mark
- Reviewers: @TechLeadClaude (code), @QAClaude (visual + a11y)
- Related: lo-user msg `74f99bc1`, UX visual evaluation `265715ca`, doc-drift DD-008