### PR TITLE
chore(deps): bump @ayingott/theme to 0.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "nuxt": "nuxt"
   },
   "dependencies": {
-    "@ayingott/theme": "0.0.1",
+    "@ayingott/theme": "0.0.2",
     "vue": "^3.5.31",
     "vue-router": "^5.0.4"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@ayingott/theme':
-        specifier: 0.0.1
-        version: 0.0.1
+        specifier: 0.0.2
+        version: 0.0.2
       vue:
         specifier: ^3.5.31
         version: 3.5.31(typescript@6.0.2)
@@ -162,8 +162,8 @@ packages:
   '@ayingott/sucrose@0.1.0':
     resolution: {integrity: sha512-dCECURW0kyOsUJnQ6Yy3kDEJmT4W7w6rMpPl8gG9pcJn1w+e/XOTqaUtgXuS6hh+hae74FWhF6jVsMj4gFCCAg==}
 
-  '@ayingott/theme@0.0.1':
-    resolution: {integrity: sha512-3Q93KABLXmVLgp4UtFO/O1RhappWj+yDYMvSRojqk1dNMgauJPi/azIaEacnXhqfm1Zj4HLw9X01iX18971RBQ==}
+  '@ayingott/theme@0.0.2':
+    resolution: {integrity: sha512-I7AWEm6GBXKntG1pR6RWOD0F43FGVSmxVPbOho5a/aoaD0o7lXobqWtpcQdZAS0pMurdJjbxHliOaMBzGNPiNg==}
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -4996,7 +4996,7 @@ snapshots:
       dotenv: 17.3.1
       dotenv-expand: 12.0.3
 
-  '@ayingott/theme@0.0.1': {}
+  '@ayingott/theme@0.0.2': {}
 
   '@babel/code-frame@7.29.0':
     dependencies:


### PR DESCRIPTION
## Summary
Picks up the focus-ring `:focus-visible` scoping fix from upstream `@ayingott/theme@0.0.2` (LoTwT/design-system PR #12 / `a3a9b18`).

## Why
- `@ayingott/theme@0.0.2` fixes the V0 always-on `focus-ring` regression that caused this site's earlier "purple ring" visual escape (PR #10 root cause).
- Consumer behavior unchanged: `focus-ring` and `focus-ring-inset` utility classes are not referenced anywhere in this codebase, verified by QAClaude in #design-system msg `45e156f2`. This is a clean dependency refresh.

## Test plan
- [x] `pnpm install` updates lockfile to 0.0.2
- [x] `pnpm lint` clean
- [x] `pnpm generate` 8 routes prerender clean
- [ ] Cloudflare Pages CI on PR head
- [ ] Cloudflare Pages production deploy after merge

## Slock Context
- **Owner**: @TechLeadClaude
- **Trigger**: @Product `87498d31` (consumer follow-up to design-system V0.0.2 ship)
- **QA verification**: @QAClaude `45e156f2` — zero `focus-ring` className references, behavior-zero impact
- **Reviewers**: self-merge per Product approval (trivial dep refresh, cross-role review waived)

## Audit trail
- design-system PR #12: <https://github.com/LoTwT/design-system/pull/12>
- design-system v0.0.2 npm: <https://www.npmjs.com/package/@ayingott/theme/v/0.0.2>