### PR TITLE
docs(ux): add §3.7 theme toggle transition contract

### DIFF
--- a/docs/ux/design-v0.1.md
+++ b/docs/ux/design-v0.1.md
@@ -242,7 +242,10 @@ function toggleTheme(event: MouseEvent) {
     return
   }
 
-  const transition = document.startViewTransition(() => setColorMode())
+  const transition = document.startViewTransition(async () => {
+    setColorMode()
+    await nextTick()
+  })
   transition.ready.then(() => {
     document.documentElement.animate(
       {
@@ -261,7 +264,22 @@ function toggleTheme(event: MouseEvent) {
 }
 ```
 
-`setColorMode()` is whatever existing color-mode mutation the S1 toggle runs (Nuxt color-mode `.dark` class swap on `<html>`). The View Transitions API takes a synchronous DOM mutation callback and handles the snapshot + cross-fade scaffolding; we override only the `new(root)` keyframe so the default cross-fade is replaced with the circle reveal.
+`setColorMode()` is whatever existing color-mode mutation the S1 toggle runs (Nuxt color-mode `.dark` class swap on `<html>`). The View Transitions API takes a DOM mutation callback and handles the snapshot + cross-fade scaffolding; we override only the `new(root)` keyframe so the default cross-fade is replaced with the circle reveal.
+
+**Two implementation bridges required for the spec's stated visual**:
+
+1. **`await nextTick()` inside the View Transition callback** — Nuxt color-mode mutates `.dark` on `<html>` reactively, which Vue applies on a microtask. A synchronous callback returns before the class change actually paints, so the View Transitions API would snapshot the _old_ theme as `new(root)`. The async callback + `await nextTick()` blocks until Vue has flushed the reactivity, ensuring the new theme is the snapshot source for the reveal.
+2. **Suppress the default UA cross-fade on both pseudo-elements** — by default browsers fade-out `::view-transition-old(root)` and fade-in `::view-transition-new(root)` simultaneously, which competes with the circle reveal on `new(root)` and breaks the "outgoing theme stays as static under-layer" model. Add a global CSS rule (`app/assets/main.css` alongside the other global resets, since the View Transitions pseudo-elements are global, not toggle-scoped):
+
+```css
+::view-transition-old(root),
+::view-transition-new(root) {
+  animation: none;
+  mix-blend-mode: normal;
+}
+```
+
+Both bridges are required — without them the spec's "outgoing under-layer + circular incoming reveal" mental model is silently broken at runtime.
 
 **Browser support and fallback**:
 

--- a/docs/ux/design-v0.1.md
+++ b/docs/ux/design-v0.1.md
@@ -205,6 +205,89 @@ Implementation lives in `app/composables/useSiteFavicon.ts`. The composable:
 
 Drift not allowed: do not add a third favicon variant for system theme; theme is user-controlled in V1 (manual toggle), and the favicon mirrors whatever the page reports.
 
+### 3.7 Theme toggle transition (circular reveal)
+
+When the visitor clicks the right-side theme toggle (light↔dark), the new theme paints in via a **circular reveal anchored at the toggle's click position**. This is the only chrome-level transition animation in V1; static toggles felt abrupt for what is otherwise a calm site.
+
+**Source of truth**: lo-user msg `74f99bc1` requested a fullscreen theme transition; UX default candidate (a) accepted in lo-user msg `63d7b9ef` 2026-05-10.
+
+**Visual model**:
+
+- Origin: the click event's `clientX` / `clientY` — i.e. exactly where the user pressed the toggle button.
+- Shape: `clip-path: circle(<radius> at <x> <y>)`, animating radius from `0` to the viewport diagonal distance from origin (so the circle sweeps through every pixel).
+- Direction: only the **incoming** theme animates in (`::view-transition-new(root)`). The outgoing theme stays as the static under-layer; the circle reveals the new theme on top of it.
+- Duration: **600ms**. Slow enough to perceive the reveal as a deliberate transition; fast enough not to block subsequent interaction.
+- Easing: `ease-out` — fast at the origin, decelerating as it expands. Reads as "light expanding outward and naturally settling."
+
+**Implementation**:
+
+The transition uses the **CSS View Transitions API** (`document.startViewTransition`). The toggle handler reads click coordinates, computes the end radius (`Math.hypot` of the larger horizontal and vertical distances to viewport edges), and animates `clip-path` on the `::view-transition-new(root)` pseudo-element.
+
+Reference shape:
+
+```ts
+function toggleTheme(event: MouseEvent) {
+  const x = event.clientX
+  const y = event.clientY
+  const endRadius = Math.hypot(
+    Math.max(x, window.innerWidth - x),
+    Math.max(y, window.innerHeight - y),
+  )
+
+  if (
+    !document.startViewTransition ||
+    window.matchMedia("(prefers-reduced-motion: reduce)").matches
+  ) {
+    setColorMode()
+    return
+  }
+
+  const transition = document.startViewTransition(() => setColorMode())
+  transition.ready.then(() => {
+    document.documentElement.animate(
+      {
+        clipPath: [
+          `circle(0 at ${x}px ${y}px)`,
+          `circle(${endRadius}px at ${x}px ${y}px)`,
+        ],
+      },
+      {
+        duration: 600,
+        easing: "ease-out",
+        pseudoElement: "::view-transition-new(root)",
+      },
+    )
+  })
+}
+```
+
+`setColorMode()` is whatever existing color-mode mutation the S1 toggle runs (Nuxt color-mode `.dark` class swap on `<html>`). The View Transitions API takes a synchronous DOM mutation callback and handles the snapshot + cross-fade scaffolding; we override only the `new(root)` keyframe so the default cross-fade is replaced with the circle reveal.
+
+**Browser support and fallback**:
+
+- **Supported**: Chromium (Chrome 111+ / Edge 111+) + WebKit (Safari 18+).
+- **Unsupported**: Firefox (no `startViewTransition` as of this spec); older Safari/Chrome. In those browsers `document.startViewTransition` is `undefined` and the early return runs `setColorMode()` synchronously — the theme swaps instantly with no animation. No JS error, no console warning.
+- **Reduced motion**: same code path as unsupported — `prefers-reduced-motion: reduce` matches → `setColorMode()` synchronously, instant swap.
+
+**Accessibility**:
+
+- The toggle's `aria-pressed` state is updated by `setColorMode()` and is observed by screen readers immediately, regardless of animation timing — visual transition runs in parallel, not in series.
+- The transition is purely decorative: no information is conveyed only through the animation.
+- Reduced-motion users get instant swap (already covered above).
+- Focus behavior is unaffected — the toggle button keeps keyboard focus through the transition.
+
+**SSR / hydration**:
+
+- View Transitions API is client-only. `document.startViewTransition` access is gated by feature detection inside the click handler (which only fires after hydration), so SSR is safe.
+- The first paint (before any toggle click) shows whatever theme `useColorMode` resolves to and never animates — matches existing S1 behavior; no flash.
+
+**Drift not allowed**:
+
+- Do not change the duration to a fixed `300ms` "snap" or `1200ms` "drama" — 600ms ease-out is the brand-tuned default. If a future iteration wants a different feel, it goes through Product/UX rather than ad-hoc tuning.
+- Do not animate the **outgoing** theme's `::view-transition-old(root)` — that produces a competing fade and breaks the "single light wave from origin" mental model.
+- Do not clamp the end radius below the diagonal — the circle must reach all four corners.
+- Do not gate the transition behind a feature flag or user preference toggle in V1 — `prefers-reduced-motion` is the single opt-out.
+
 ---
 
 ## 4. Page wireframes


### PR DESCRIPTION
## Summary

C-2 spec entry per lo-user msg \`74f99bc1\` (request) + \`63d7b9ef\` (option (a) accepted): add §3.7 Theme toggle transition contract to \`docs/ux/design-v0.1.md\` so TechLead has a single spec-of-record before implementing the runtime change in \`app/components/theme/toggle.vue\`.

## What changed

- \`docs/ux/design-v0.1.md\` — single new section §3.7 (Theme toggle transition, circular reveal). +83 lines, 0 deletions. Sits between §3.6 (Favicon) and the §4 page wireframes block; preserves existing numbering.

## Spec at a glance

- **Visual model**: \`clip-path: circle(0 → diagonal-radius at clientX clientY)\` on \`::view-transition-new(root)\`, 600ms ease-out
- **API**: \`document.startViewTransition\` + \`document.documentElement.animate\` (CSS View Transitions)
- **Browser support**: Chrome 111+ / Edge 111+ / Safari 18+
- **Fallback**: feature detection on \`document.startViewTransition\` (undefined in Firefox / older WebKit) → instant \`setColorMode()\` swap, no error
- **Reduced motion**: \`prefers-reduced-motion: reduce\` takes the same instant-swap path
- **A11y**: \`aria-pressed\` updates immediately regardless of animation; transition is purely decorative; focus preserved
- **SSR safe**: feature detection inside click handler, client-only — first paint never animates
- **Drift constraints**: no duration tweaks, no \`::view-transition-old\` animation, no clamped end radius, no V1 user opt-out flag

## Why

V13 brought an animated cursive Lo signature to the hero — instant theme swap by contrast feels jarring after such a deliberate motion identity. Circle-from-toggle reveal anchors the cause (the click) to the effect (light expanding outward) in physical space, matching the brand's "calm but considered motion" register without adding chrome ornamentation.

UX considered fade / wipe / slide alternatives (msg \`f50a09cd\`); the circle reveal won on three grounds: (a) spatial cause-effect from origin point, (b) View Transitions API native support means trivial implementation + clean fallback, (c) consistent with the reveal-from-origin language already used by the Lo signature stroke animation in §4.7.

## Test plan

- [ ] Doc-only PR — no code, no token, no exports change
- [ ] Section ordering: §3.5 → §3.6 → §3.7 (verified via \`grep -n '^### 3\\.' docs/ux/design-v0.1.md\`)
- [ ] Runtime implementation in a follow-up by TechLeadClaude (\`app/components/theme/toggle.vue\`)

## Slock context

- Owner: @UX (spec)
- Implementation owner: @TechLeadClaude (\`app/components/theme/toggle.vue\` view-transition logic + reduced-motion guard)
- Reviewers: @QAClaude (live verify Chrome animation + Firefox instant fallback + reduced-motion instant + a11y not broken)
- Related: lo-user msgs \`74f99bc1\` / \`63d7b9ef\`, UX spec discussion \`f50a09cd\`, doc-drift DD-009
- Will pair with TLClaude runtime PR before Product 起 v14 整合公告（含 C-1 / theme dep bump 0.0.2 / C-2）