### PR TITLE
feat(theme): circular reveal toggle transition

### DIFF
--- a/app/assets/main.css
+++ b/app/assets/main.css
@@ -29,3 +29,18 @@ button,
 a {
   -webkit-tap-highlight-color: transparent;
 }
+
+/*
+ * Theme toggle view transition (design-v0.1 §3.7).
+ *
+ * Suppresses the user-agent's default cross-fade between the old and new
+ * theme snapshots. The toggle handler animates a circular clip-path on
+ * ::view-transition-new(root) instead, so only the incoming theme reveals
+ * outward from the click position; the outgoing theme stays as the static
+ * under-layer (per §3.7 "Drift not allowed").
+ */
+::view-transition-old(root),
+::view-transition-new(root) {
+  animation: none;
+  mix-blend-mode: normal;
+}

--- a/app/components/theme/toggle.vue
+++ b/app/components/theme/toggle.vue
@@ -4,9 +4,68 @@ const toggleLabel = computed(() =>
   isDark.value ? "切换到亮色模式" : "切换到暗色模式",
 )
 
-function toggleDark() {
-  const payload = isDark.value ? "light" : "dark"
-  colorMode.preference = payload
+// design-v0.1 §3.7 — circular reveal theme toggle transition.
+// Origin: click coordinates; radius: viewport diagonal; duration: 600ms ease-out.
+// Falls back to instant swap when View Transitions API is missing or
+// `prefers-reduced-motion: reduce` matches.
+async function toggleDark(event: MouseEvent) {
+  function applyPreference() {
+    colorMode.preference = isDark.value ? "light" : "dark"
+  }
+
+  // SSR-safe: every API used below is window/document; this handler only
+  // fires post-hydration, but guard the matchMedia call anyway.
+  const reducedMotion =
+    typeof window !== "undefined" &&
+    window.matchMedia("(prefers-reduced-motion: reduce)").matches
+
+  if (
+    typeof document === "undefined" ||
+    typeof document.startViewTransition !== "function" ||
+    reducedMotion
+  ) {
+    applyPreference()
+    return
+  }
+
+  const x = event.clientX
+  const y = event.clientY
+  const endRadius = Math.hypot(
+    Math.max(x, window.innerWidth - x),
+    Math.max(y, window.innerHeight - y),
+  )
+
+  const transition = document.startViewTransition(async () => {
+    applyPreference()
+    // Wait one tick so Vue's reactive `.dark` class swap on <html> lands
+    // before the View Transitions API captures the new snapshot. Without
+    // this the snapshot is captured pre-flush and the new theme never
+    // reaches the post-transition raster.
+    await nextTick()
+  })
+
+  try {
+    await transition.ready
+  } catch {
+    // `transition.ready` rejects when the browser bails out of the
+    // transition for any reason (e.g. concurrent transition); the theme
+    // mutation has already happened inside the callback, so just stop here.
+    return
+  }
+
+  document.documentElement.animate(
+    {
+      clipPath: [
+        `circle(0px at ${x}px ${y}px)`,
+        `circle(${endRadius}px at ${x}px ${y}px)`,
+      ],
+    },
+    {
+      duration: 600,
+      easing: "ease-out",
+      pseudoElement: "::view-transition-new(root)",
+    },
+  )
 }
 </script>
 


### PR DESCRIPTION
## Summary
Implements the C-2 theme toggle transition contract from [`docs/ux/design-v0.1.md` §3.7](../blob/main/docs/ux/design-v0.1.md#37-theme-toggle-transition-circular-reveal): a circular reveal anchored at the toggle click position, animating `clip-path` from `circle(0 at x y)` to `circle(<viewport-diagonal> at x y)` in 600ms ease-out via the CSS View Transitions API.

## Changes

### `app/components/theme/toggle.vue`
- `toggleDark()` becomes async and takes the click `MouseEvent`.
- Falls back to the existing instant `colorMode.preference` swap when:
  - `document.startViewTransition` is `undefined` (Firefox, older browsers), or
  - `prefers-reduced-motion: reduce` matches.
- Otherwise reads `event.clientX/Y`, computes the end radius via `Math.hypot`, calls `document.startViewTransition` with an async callback that mutates `colorMode.preference` and `await nextTick()` so Vue's reactive `.dark` class swap on `<html>` lands before the new snapshot is captured (one of the two implementation bridges UX added to spec in `79e670c7`).
- Animates `clip-path` on `::view-transition-new(root)` after `transition.ready` resolves.
- Catches `transition.ready` rejection so a browser bail-out (e.g. concurrent transition) doesn't surface as an unhandled promise; the theme mutation has already happened inside the callback in that case.

### `app/assets/main.css`
- Adds the second implementation bridge from §3.7: `::view-transition-old(root)` and `::view-transition-new(root)` get `animation: none; mix-blend-mode: normal`. Without this the user-agent default cross-fade competes with the custom `Element.animate` clip-path and the "single light wave from origin" visual model breaks.

## a11y / SSR
- `aria-pressed` is bound to `isDark` in the template; it flips the moment `colorMode.preference` is set and is read by AT immediately, in parallel with the visual transition.
- Reduced-motion users get instant swap via the early-return path.
- All `window` / `document` access is inside the click handler, which only runs post-hydration; SSR-safe.

## Test plan
- [x] `pnpm install --frozen-lockfile` clean
- [x] `pnpm lint` 0 errors / 0 warnings (auto-fixed one prettier nit)
- [x] `git diff --check` clean
- [x] `pnpm generate` 8 routes prerender clean; only the known `@tailwindcss/vite` sourcemap warning
- [x] Compiled CSS contains `::view-transition-old(root){animation:none;mix-blend-mode:normal}::view-transition-new(root){animation:none;mix-blend-mode:normal}`
- [ ] @QAClaude live verification: Chrome/Edge plays the circular reveal at click position with 600ms ease-out; Firefox falls back to instant swap with no JS error; reduced-motion falls back to instant swap; `aria-pressed` flips immediately.
- [ ] Cloudflare Pages PR check + main deploy after merge

## Slock Context
- **Owner**: @TechLeadClaude
- **Trigger**: @lo-user `74f99bc1` requested fullscreen theme transition; `63d7b9ef` picked option (a)
- **Spec**: PR #15 `a811c4d` `docs(ux): add §3.7 theme toggle transition contract (#15)` (UX-led, merged 2026-05-10)
- **Implementation bridges**: spec amended in `9ca5612` per TL `581dcfcb`; both bridges land in this PR
- **Reviewers**: @QAClaude — critical path (Chrome view-transition rendering, Firefox/reduced-motion fallback, a11y, SSR-hydration)

## Cannot exercise locally without dev server
The View Transitions API only fires in a real browser context. `pnpm generate` confirms TypeScript / lint / build / static prerender are clean, and the compiled CSS confirms the cross-fade kill rules made it in. The visual transition itself needs Chrome live (and Firefox for fallback); QA owns that.