### PR TITLE
fix(blog): prerender content routes for Pages

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,5 +1,87 @@
 // https://nuxt.com/docs/api/configuration/nuxt-config
+import { existsSync, readdirSync, readFileSync } from "node:fs"
+import { join, relative, sep } from "node:path"
+import { fileURLToPath } from "node:url"
 import tailwindcss from "@tailwindcss/vite"
+
+const blogContentRoot = fileURLToPath(
+  new URL("./content/blog", import.meta.url),
+)
+const markdownExtension = ".md"
+const draftFileExtension = ".draft.md"
+const wrappingQuotePattern = /^["']|["']$/g
+
+function collectMarkdownFiles(directory: string): string[] {
+  if (!existsSync(directory)) {
+    return []
+  }
+
+  return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const fullPath = join(directory, entry.name)
+
+    if (entry.isDirectory()) {
+      return collectMarkdownFiles(fullPath)
+    }
+
+    return entry.isFile() && entry.name.endsWith(markdownExtension)
+      ? [fullPath]
+      : []
+  })
+}
+
+function readFrontmatter(source: string) {
+  if (!source.startsWith("---\n")) {
+    return new Map<string, string>()
+  }
+
+  const end = source.indexOf("\n---", 4)
+
+  if (end === -1) {
+    return new Map<string, string>()
+  }
+
+  return new Map(
+    source
+      .slice(4, end)
+      .split("\n")
+      .map((line) => line.trim())
+      .filter((line) => line.includes(":"))
+      .map((line) => {
+        const separator = line.indexOf(":")
+        const key = line.slice(0, separator).trim()
+        const value = line
+          .slice(separator + 1)
+          .trim()
+          .replace(wrappingQuotePattern, "")
+
+        return [key, value] as const
+      }),
+  )
+}
+
+function getBlogPrerenderRoutes() {
+  const routes = collectMarkdownFiles(blogContentRoot)
+    .filter((filePath) => !filePath.endsWith(draftFileExtension))
+    .flatMap((filePath) => {
+      const source = readFileSync(filePath, "utf8")
+      const frontmatter = readFrontmatter(source)
+
+      if (frontmatter.get("draft") === "true") {
+        return []
+      }
+
+      const frontmatterSlug = frontmatter.get("slug")?.trim()
+      const fileSlug = relative(blogContentRoot, filePath)
+        .slice(0, -markdownExtension.length)
+        .split(sep)
+        .join("/")
+      const slug = frontmatterSlug || fileSlug
+
+      return slug ? [`/blog/${slug}`] : []
+    })
+
+  return Array.from(new Set(["/blog", ...routes])).sort()
+}
 
 export default defineNuxtConfig({
   compatibilityDate: "2026-03-31",
@@ -50,7 +132,7 @@ export default defineNuxtConfig({
 
   nitro: {
     prerender: {
-      routes: ["/feed.xml", "/sitemap.xml"],
+      routes: [...getBlogPrerenderRoutes(), "/feed.xml", "/sitemap.xml"],
     },
   },
 


### PR DESCRIPTION
## Summary
- prerender /blog plus non-draft /blog/<slug> routes during Nuxt build
- derive blog prerender routes from content/blog markdown files while excluding .draft.md and draft:true files
- keep feed/sitemap prerender behavior unchanged

## Why
Post-merge production smoke showed Cloudflare Pages build was green, and feed/sitemap had the article, but /blog rendered empty and /blog/hello-phase-a returned the site 404. The SSR runtime query path is not safe for Nuxt Content on the Pages runtime, so blog pages need build-time static output like feed/sitemap.

## Verification
- pnpm lint
- pnpm exec vue-tsc --noEmit
- pnpm build
- git diff --check HEAD
- local .output server smoke: /blog 200 with article, /blog/hello-phase-a 200 with article, /feed.xml and /sitemap.xml include hello-phase-a, /blog/draft-example 404 without draft title/content
