### PR TITLE
feat(home): implement Phase B home slice

### DIFF
--- a/app/components/home/HomeContactList.vue
+++ b/app/components/home/HomeContactList.vue
@@ -1,0 +1,60 @@
+<script setup lang="ts">
+import type { ContactLink } from "~/composables/useSiteContent"
+
+defineProps<{
+  links: ContactLink[]
+}>()
+</script>
+
+<template>
+  <nav class="home-contact-list" aria-label="联系方式">
+    <NuxtLink
+      v-for="link in links"
+      :key="link.key"
+      class="home-contact-list__link"
+      :to="link.href"
+      :external="link.external"
+      :target="link.external ? '_blank' : undefined"
+      :rel="link.external ? 'noreferrer' : undefined"
+    >
+      {{ link.label }}
+    </NuxtLink>
+  </nav>
+</template>
+
+<style scoped>
+.home-contact-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-3) var(--spacing-5);
+}
+
+.home-contact-list__link {
+  min-height: var(--touch-target-min);
+  display: inline-flex;
+  align-items: center;
+  border-radius: var(--radius-control);
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  line-height: var(--text-sm--line-height);
+  text-decoration-color: color-mix(
+    in srgb,
+    var(--text-accent) 45%,
+    transparent
+  );
+  text-underline-offset: 0.28em;
+  transition: var(--transition-interactive);
+}
+
+.home-contact-list__link:hover {
+  color: var(--text-accent);
+  text-decoration-color: var(--text-accent);
+}
+
+.home-contact-list__link:focus-visible {
+  outline: 2px solid var(--focus-ring-color);
+  outline-offset: 2px;
+  box-shadow: var(--focus-ring-shadow);
+}
+</style>

--- a/app/components/home/HomeHero.vue
+++ b/app/components/home/HomeHero.vue
@@ -1,0 +1,149 @@
+<script setup lang="ts">
+import LoSignatureMark from "~/components/site/LoSignatureMark.vue"
+
+defineProps<{
+  tagline: string
+  nowText?: string
+}>()
+</script>
+
+<template>
+  <header class="home-hero">
+    <h1 id="home-title" class="home-hero__title" aria-label="Hi, I'm Lo.">
+      <span class="home-hero__title-text" aria-hidden="true">Hi, I'm</span>
+      <span class="home-hero__signature" aria-hidden="true">
+        <LoSignatureMark />
+      </span>
+      <span class="home-hero__signature-period" aria-hidden="true">.</span>
+      <span class="home-hero__emoji" aria-hidden="true">👋</span>
+    </h1>
+
+    <p class="home-hero__tagline">{{ tagline }}</p>
+    <p v-if="nowText" class="home-hero__now">
+      <span class="home-hero__now-label">现在</span>
+      <span aria-hidden="true"> · </span>
+      {{ nowText }}
+    </p>
+  </header>
+</template>
+
+<style scoped>
+.home-hero {
+  display: grid;
+  justify-items: center;
+  gap: var(--spacing-5);
+  text-align: center;
+}
+
+.home-hero__title {
+  max-width: 18ch;
+  margin: 0;
+  display: flex;
+  flex-wrap: nowrap;
+  align-items: center;
+  justify-content: center;
+  gap: 0;
+  color: var(--text-primary);
+  font-family: var(--font-display);
+  font-size: var(--text-5xl);
+  line-height: 1.5;
+  font-weight: var(--font-weight-bold);
+  letter-spacing: var(--tracking-tight);
+}
+
+.home-hero__title-text,
+.home-hero__signature,
+.home-hero__signature-period,
+.home-hero__emoji {
+  flex: 0 0 auto;
+}
+
+.home-hero__signature {
+  display: inline-flex;
+  margin-inline: 0.5rem;
+  --lo-signature-width: 4.8rem;
+  --lo-signature-height: 3.2rem;
+  --lo-signature-stroke-width: 0.35;
+}
+
+.home-hero__signature-period {
+  display: inline-block;
+  margin-inline-end: 0.25rem;
+}
+
+.home-hero__emoji {
+  display: inline-block;
+  margin-inline-start: 0;
+  transform-origin: 70% 70%;
+  animation: home-emoji-wave 2.8s ease-in-out infinite;
+}
+
+.home-hero__tagline {
+  max-width: 30rem;
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: var(--text-xl);
+  line-height: var(--text-xl--line-height);
+}
+
+.home-hero__now {
+  margin: 0;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  line-height: var(--text-sm--line-height);
+}
+
+.home-hero__now-label {
+  color: var(--text-accent);
+}
+
+@media (max-width: 720px) {
+  .home-hero__title {
+    max-width: 100%;
+    font-size: var(--text-4xl);
+    line-height: 1.5;
+  }
+
+  .home-hero__signature {
+    margin-inline: 0.375rem;
+    --lo-signature-width: 4.8rem;
+    --lo-signature-height: 3.2rem;
+    --lo-signature-stroke-width: 0.35;
+  }
+}
+
+@keyframes home-emoji-wave {
+  0%,
+  42%,
+  100% {
+    transform: rotate(0deg);
+  }
+
+  6% {
+    transform: rotate(14deg);
+  }
+
+  12% {
+    transform: rotate(-8deg);
+  }
+
+  18% {
+    transform: rotate(12deg);
+  }
+
+  24% {
+    transform: rotate(-4deg);
+  }
+
+  30% {
+    transform: rotate(6deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .home-hero__emoji {
+    animation: none;
+  }
+}
+</style>

--- a/app/components/home/HomeSection.vue
+++ b/app/components/home/HomeSection.vue
@@ -1,0 +1,111 @@
+<script setup lang="ts">
+defineProps<{
+  sectionId: string
+  label: string
+  title: string
+  actionLabel?: string
+  actionTo?: string
+}>()
+</script>
+
+<template>
+  <section class="home-section" :aria-labelledby="`${sectionId}-title`">
+    <div class="home-section__header">
+      <div>
+        <p class="home-section__kicker">{{ label }}</p>
+        <h2 :id="`${sectionId}-title`" class="home-section__title">
+          {{ title }}
+        </h2>
+      </div>
+
+      <NuxtLink
+        v-if="actionLabel && actionTo"
+        class="home-section__action"
+        :to="actionTo"
+      >
+        {{ actionLabel }}
+        <span aria-hidden="true">→</span>
+      </NuxtLink>
+    </div>
+
+    <slot />
+  </section>
+</template>
+
+<style scoped>
+.home-section {
+  display: grid;
+  gap: var(--spacing-5);
+}
+
+.home-section__header {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: var(--spacing-4);
+}
+
+.home-section__kicker {
+  margin: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-3);
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  line-height: var(--text-xs--line-height);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.home-section__kicker::before {
+  content: "";
+  width: 1.4rem;
+  height: 2px;
+  flex: 0 0 auto;
+  background: var(--text-accent);
+  opacity: 0.85;
+}
+
+.home-section__title {
+  margin: var(--spacing-2) 0 0;
+  color: var(--text-primary);
+  font-family: var(--font-display);
+  font-size: var(--text-2xl);
+  line-height: var(--text-2xl--line-height);
+  font-weight: var(--font-weight-medium);
+  letter-spacing: var(--tracking-normal);
+}
+
+.home-section__action {
+  min-height: var(--touch-target-min);
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-2);
+  border-radius: var(--radius-control);
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  line-height: var(--text-sm--line-height);
+  text-decoration: none;
+  transition: var(--transition-interactive);
+}
+
+.home-section__action:hover {
+  color: var(--text-accent);
+}
+
+.home-section__action:focus-visible {
+  outline: 2px solid var(--focus-ring-color);
+  outline-offset: 2px;
+  box-shadow: var(--focus-ring-shadow);
+}
+
+@media (max-width: 560px) {
+  .home-section__header {
+    align-items: start;
+    flex-direction: column;
+    gap: var(--spacing-3);
+  }
+}
+</style>

--- a/app/components/home/HomeWorkList.vue
+++ b/app/components/home/HomeWorkList.vue
@@ -1,0 +1,175 @@
+<script setup lang="ts">
+import type { FeaturedWork } from "~/composables/useSiteContent"
+
+defineProps<{
+  items: FeaturedWork[]
+}>()
+</script>
+
+<template>
+  <div class="home-work-list" aria-label="在做的项目">
+    <NuxtLink
+      v-for="item in items"
+      :key="item.key"
+      class="home-work-row"
+      :to="item.href"
+      :external="item.external"
+      :target="item.external ? '_blank' : undefined"
+      :rel="item.external ? 'noopener noreferrer' : undefined"
+    >
+      <span class="home-work-row__main">
+        <span class="home-work-row__name">
+          {{ item.title }}
+          <span class="home-work-row__arrow" aria-hidden="true">↗</span>
+        </span>
+        <span class="home-work-row__description">
+          {{ item.description }}
+        </span>
+      </span>
+
+      <span class="home-work-row__side">
+        <span class="home-work-row__year">{{ item.year }}</span>
+        <span class="home-work-row__tags" aria-label="标签">
+          <span v-for="tag in item.tags" :key="tag" class="home-work-row__tag">
+            {{ tag }}
+          </span>
+        </span>
+      </span>
+    </NuxtLink>
+  </div>
+</template>
+
+<style scoped>
+.home-work-list {
+  display: grid;
+}
+
+.home-work-row {
+  min-width: 0;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: start;
+  gap: var(--spacing-5);
+  border-top: 1px solid var(--border-subtle);
+  padding-block: var(--spacing-5);
+  color: inherit;
+  text-align: left;
+  text-decoration: none;
+  transition: var(--transition-interactive);
+}
+
+.home-work-row:last-child {
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.home-work-row__main {
+  min-width: 0;
+  display: grid;
+  gap: var(--spacing-2);
+}
+
+.home-work-row__name {
+  min-width: 0;
+  color: var(--text-primary);
+  font-family: var(--font-display);
+  font-size: var(--text-xl);
+  line-height: var(--text-xl--line-height);
+  font-weight: var(--font-weight-medium);
+  overflow-wrap: anywhere;
+  transition: var(--transition-interactive);
+}
+
+.home-work-row__arrow {
+  display: inline-block;
+  margin-inline-start: var(--spacing-1);
+  color: var(--text-muted);
+  transition: var(--transition-interactive);
+}
+
+.home-work-row__description {
+  max-width: 46ch;
+  color: var(--text-muted);
+  font-size: var(--text-base);
+  line-height: var(--text-base--line-height);
+}
+
+.home-work-row__side {
+  display: grid;
+  justify-items: end;
+  gap: var(--spacing-3);
+}
+
+.home-work-row__year {
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  line-height: var(--text-xs--line-height);
+}
+
+.home-work-row__tags {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: var(--spacing-2);
+}
+
+.home-work-row__tag {
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-control);
+  padding: 0.125rem var(--spacing-2);
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  line-height: var(--text-xs--line-height);
+}
+
+.home-work-row:hover {
+  padding-inline-start: var(--spacing-2);
+}
+
+.home-work-row:hover .home-work-row__name {
+  color: var(--text-accent);
+}
+
+.home-work-row:hover .home-work-row__arrow {
+  color: var(--text-accent);
+  transform: translateX(4px);
+}
+
+.home-work-row:focus-visible {
+  outline: 2px solid var(--focus-ring-color);
+  outline-offset: 3px;
+  box-shadow: var(--focus-ring-shadow);
+}
+
+@media (max-width: 640px) {
+  .home-work-row {
+    grid-template-columns: 1fr;
+    gap: var(--spacing-3);
+  }
+
+  .home-work-row__side {
+    justify-items: start;
+  }
+
+  .home-work-row__tags {
+    justify-content: flex-start;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .home-work-row,
+  .home-work-row__name,
+  .home-work-row__arrow {
+    transition: none;
+  }
+
+  .home-work-row:hover {
+    padding-inline-start: 0;
+  }
+
+  .home-work-row:hover .home-work-row__arrow {
+    transform: none;
+  }
+}
+</style>

--- a/app/components/home/HomeWritingList.vue
+++ b/app/components/home/HomeWritingList.vue
@@ -1,0 +1,138 @@
+<script setup lang="ts">
+import type { BlogPostLike } from "~/utils/blog"
+import { computed } from "vue"
+import { formatBlogDate, getBlogPostHref } from "~/utils/blog"
+
+const props = defineProps<{
+  posts: BlogPostLike[]
+}>()
+
+const rows = computed(() =>
+  props.posts.map((post) => ({
+    key: post.path,
+    title: post.title,
+    href: getBlogPostHref(post),
+    date: formatBlogDate(post.date),
+    description: post.description,
+  })),
+)
+</script>
+
+<template>
+  <div v-if="rows.length" class="home-writing-list" aria-label="最近文章">
+    <NuxtLink
+      v-for="row in rows"
+      :key="row.key"
+      class="home-writing-row"
+      :to="row.href"
+    >
+      <span class="home-writing-row__meta">{{ row.date }}</span>
+      <span class="home-writing-row__body">
+        <span class="home-writing-row__title">{{ row.title }}</span>
+        <span class="home-writing-row__description">
+          {{ row.description }}
+        </span>
+      </span>
+    </NuxtLink>
+  </div>
+
+  <p v-else class="home-writing-empty">
+    第一篇真实文章准备好后,这里会变成最近写作的入口。
+  </p>
+</template>
+
+<style scoped>
+.home-writing-list {
+  display: grid;
+}
+
+.home-writing-row {
+  min-width: 0;
+  display: grid;
+  grid-template-columns: minmax(5.5rem, 7rem) minmax(0, 1fr);
+  gap: var(--spacing-5);
+  border-top: 1px solid var(--border-subtle);
+  padding-block: var(--spacing-5);
+  color: inherit;
+  text-align: left;
+  text-decoration: none;
+  transition: var(--transition-interactive);
+}
+
+.home-writing-row:last-child {
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.home-writing-row__meta {
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  line-height: var(--text-xs--line-height);
+}
+
+.home-writing-row__body {
+  min-width: 0;
+  display: grid;
+  gap: var(--spacing-2);
+}
+
+.home-writing-row__title {
+  min-width: 0;
+  color: var(--text-primary);
+  font-family: var(--font-display);
+  font-size: var(--text-xl);
+  line-height: var(--text-xl--line-height);
+  font-weight: var(--font-weight-medium);
+  overflow-wrap: anywhere;
+  transition: var(--transition-interactive);
+}
+
+.home-writing-row__description {
+  max-width: 46ch;
+  color: var(--text-muted);
+  font-size: var(--text-base);
+  line-height: var(--text-base--line-height);
+}
+
+.home-writing-row:hover {
+  padding-inline-start: var(--spacing-2);
+}
+
+.home-writing-row:hover .home-writing-row__title {
+  color: var(--text-accent);
+}
+
+.home-writing-row:focus-visible {
+  outline: 2px solid var(--focus-ring-color);
+  outline-offset: 3px;
+  box-shadow: var(--focus-ring-shadow);
+}
+
+.home-writing-empty {
+  margin: 0;
+  border-top: 1px solid var(--border-subtle);
+  border-bottom: 1px solid var(--border-subtle);
+  padding-block: var(--spacing-5);
+  color: var(--text-muted);
+  font-size: var(--text-base);
+  line-height: var(--text-base--line-height);
+}
+
+@media (max-width: 560px) {
+  .home-writing-row {
+    grid-template-columns: 1fr;
+    gap: var(--spacing-2);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .home-writing-row,
+  .home-writing-row__title {
+    transition: none;
+  }
+
+  .home-writing-row:hover {
+    padding-inline-start: 0;
+  }
+}
+</style>

--- a/app/composables/useSiteContent.ts
+++ b/app/composables/useSiteContent.ts
@@ -16,6 +16,16 @@ export interface BlogPostSummary {
   excerpt: string
 }
 
+export interface FeaturedWork {
+  key: string
+  title: string
+  href: string
+  year: string
+  description: string
+  tags: string[]
+  external?: boolean
+}
+
 const emailUser = "hi"
 const emailHost = "ayingott.me"
 
@@ -48,6 +58,26 @@ export function useSiteContent() {
   ]
 
   const posts = [] as BlogPostSummary[]
+  const featuredWorks: FeaturedWork[] = [
+    {
+      key: "miru",
+      title: "miru",
+      href: "https://miru.ayingott.me",
+      year: "2026",
+      description: "一个安静的 Markdown 阅读器,把排版和阅读状态放在第一位。",
+      tags: ["reading", "pwa"],
+      external: true,
+    },
+    {
+      key: "yomu",
+      title: "yomu",
+      href: "https://yomu.ayingott.me",
+      year: "2026",
+      description: "每日发声阅读练习,用文章、领读和对照翻译建立语言节奏。",
+      tags: ["read aloud", "language"],
+      external: true,
+    },
+  ]
 
   const contactLinks = computed<ContactLink[]>(() => {
     const email = decodeEmail()
@@ -101,6 +131,7 @@ export function useSiteContent() {
     navItems,
     nowText,
     contactLinks,
+    featuredWorks,
     posts,
   }
 }

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -67,6 +67,7 @@ useSiteSeo({
   min-height: calc(100svh - 160px);
   margin-inline: auto;
   display: grid;
+  align-content: start;
   gap: clamp(var(--spacing-12), 9vw, var(--spacing-20));
   padding-block: clamp(var(--spacing-14), 14svh, 9rem) var(--spacing-12);
 }

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -1,12 +1,27 @@
 <script setup lang="ts">
-import ContactStrip from "~/components/site/ContactStrip.vue"
-import LoSignatureMark from "~/components/site/LoSignatureMark.vue"
+import { computed } from "vue"
+import HomeContactList from "~/components/home/HomeContactList.vue"
+import HomeHero from "~/components/home/HomeHero.vue"
+import HomeSection from "~/components/home/HomeSection.vue"
+import HomeWorkList from "~/components/home/HomeWorkList.vue"
+import HomeWritingList from "~/components/home/HomeWritingList.vue"
 
 definePageMeta({
   layout: "home",
 })
 
-const { identity, nowText } = useSiteContent()
+async function queryRecentPosts() {
+  return queryCollection("blog")
+    .where("draft", "<>", true)
+    .order("date", "DESC")
+    .all()
+}
+
+const { data } = await useAsyncData("home-recent-posts", queryRecentPosts)
+const { identity, nowText, contactLinks, featuredWorks } = useSiteContent()
+
+const recentPosts = computed(() => (data.value ?? []).slice(0, 3))
+const highlightedWorks = computed(() => featuredWorks.slice(0, 2))
 
 useSiteSeo({
   title: "ayingott.me",
@@ -18,183 +33,53 @@ useSiteSeo({
 
 <template>
   <section class="home-page" aria-labelledby="home-title">
-    <div class="home-page__copy">
-      <h1 id="home-title" class="home-page__title" aria-label="Hi, I'm Lo.">
-        <span class="home-page__title-text" aria-hidden="true">Hi, I'm</span>
-        <span class="home-page__signature" aria-hidden="true"
-          ><LoSignatureMark /></span
-        ><span class="home-page__signature-period" aria-hidden="true">.</span>
-        <span class="home-page__emoji" aria-hidden="true">👋</span>
-      </h1>
-      <p class="home-page__tagline">{{ identity.homeTagline }}</p>
+    <HomeHero :tagline="identity.homeTagline" :now-text="nowText" />
+
+    <div class="home-page__sections">
+      <HomeSection
+        section-id="writing"
+        label="最近写的 · Writing"
+        title="最近写的"
+        action-label="全部文章"
+        action-to="/blog"
+      >
+        <HomeWritingList :posts="recentPosts" />
+      </HomeSection>
+
+      <HomeSection
+        section-id="works-preview"
+        label="在做的 · Works"
+        title="在做的"
+      >
+        <HomeWorkList :items="highlightedWorks" />
+      </HomeSection>
+
+      <HomeSection section-id="elsewhere" label="联系 · Elsewhere" title="联系">
+        <HomeContactList :links="contactLinks" />
+      </HomeSection>
     </div>
-
-    <ul
-      v-if="identity.interests.length"
-      class="home-page__interests"
-      aria-label="兴趣"
-    >
-      <li v-for="interest in identity.interests" :key="interest">
-        {{ interest }}
-      </li>
-    </ul>
-
-    <p v-if="nowText" class="home-page__now">{{ nowText }}</p>
-
-    <ContactStrip />
   </section>
 </template>
 
 <style scoped>
 .home-page {
-  width: min(100%, var(--container-reading));
+  width: min(100%, 52rem);
   min-height: calc(100svh - 160px);
   margin-inline: auto;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: flex-start;
-  gap: var(--spacing-8);
-  padding-block: clamp(var(--spacing-16), 18svh, 11rem) var(--spacing-12);
-  text-align: center;
+  display: grid;
+  gap: clamp(var(--spacing-12), 9vw, var(--spacing-20));
+  padding-block: clamp(var(--spacing-14), 14svh, 9rem) var(--spacing-12);
 }
 
-.home-page__copy {
-  max-width: 640px;
-  margin-inline: auto;
-}
-
-.home-page__title {
-  max-width: 18ch;
-  margin: 0;
-  display: flex;
-  flex-wrap: nowrap;
-  align-items: center;
-  justify-content: center;
-  gap: 0;
-  color: var(--text-primary);
-  font-family: var(--font-display);
-  font-size: var(--text-5xl);
-  line-height: 1.5;
-  font-weight: var(--font-weight-bold);
-  letter-spacing: var(--tracking-tight);
-}
-
-.home-page__signature {
-  display: inline-flex;
-  flex: 0 0 auto;
-  margin-inline: 0.5rem;
-  --lo-signature-width: 4.8rem;
-  --lo-signature-height: 3.2rem;
-  --lo-signature-stroke-width: 0.35;
-}
-
-.home-page__signature-period {
-  display: inline-block;
-  flex: 0 0 auto;
-  margin-inline-end: 0.25rem;
-}
-
-.home-page__emoji {
-  display: inline-block;
-  flex: 0 0 auto;
-  margin-inline-start: 0;
-  transform-origin: 70% 70%;
-  animation: home-emoji-wave 2.8s ease-in-out infinite;
-}
-
-.home-page__title-text {
-  flex: 0 0 auto;
-}
-
-.home-page__tagline {
-  max-width: 28rem;
-  margin: var(--spacing-6) auto 0;
-  color: var(--text-secondary);
-  font-size: var(--text-xl);
-  line-height: var(--text-xl--line-height);
-}
-
-.home-page__interests {
-  margin: 0;
-  padding: 0;
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: center;
-  gap: var(--spacing-3);
-  list-style: none;
-}
-
-.home-page__interests li {
-  border: 1px solid var(--border-subtle);
-  border-radius: var(--radius-control);
-  padding: var(--spacing-2) var(--spacing-3);
-  color: var(--text-muted);
-  font-family: var(--font-mono);
-  font-size: var(--text-xs);
-  line-height: var(--text-xs--line-height);
-}
-
-.home-page__now {
-  max-width: 40rem;
-  margin: 0;
-  color: var(--text-muted);
-  font-family: var(--font-mono);
-  font-size: var(--text-sm);
-  line-height: var(--text-sm--line-height);
+.home-page__sections {
+  display: grid;
+  gap: var(--spacing-12);
 }
 
 @media (max-width: 720px) {
   .home-page {
     min-height: auto;
     padding-block: var(--spacing-8);
-  }
-
-  .home-page__title {
-    max-width: 100%;
-    font-size: var(--text-4xl);
-    line-height: 1.5;
-  }
-
-  .home-page__signature {
-    margin-inline: 0.375rem;
-    --lo-signature-width: 4.8rem;
-    --lo-signature-height: 3.2rem;
-    --lo-signature-stroke-width: 0.35;
-  }
-}
-
-@keyframes home-emoji-wave {
-  0%,
-  42%,
-  100% {
-    transform: rotate(0deg);
-  }
-
-  6% {
-    transform: rotate(14deg);
-  }
-
-  12% {
-    transform: rotate(-8deg);
-  }
-
-  18% {
-    transform: rotate(12deg);
-  }
-
-  24% {
-    transform: rotate(-4deg);
-  }
-
-  30% {
-    transform: rotate(6deg);
-  }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .home-page__emoji {
-    animation: none;
   }
 }
 </style>

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -80,7 +80,7 @@ function getBlogPrerenderRoutes() {
       return slug ? [`/blog/${slug}`] : []
     })
 
-  return Array.from(new Set(["/blog", ...routes])).sort()
+  return Array.from(new Set(["/", "/blog", ...routes])).sort()
 }
 
 export default defineNuxtConfig({


### PR DESCRIPTION
## Summary
- Reworks the home page into the Phase B editorial front door from UX hi-fi: hero, recent writing, works preview, and contact sections.
- Adds focused home components for hero/section/writing/work/contact rows and shared `featuredWorks` content for miru/yomu.
- Adds `/` to build-time prerender routes so the home slice follows the Phase A Cloudflare Pages prerender constraint.

## Scope notes
- This PR intentionally does **not** add `/works` navigation or a works-page link yet, because the works route/content is a later slice pending lo-user confirmation.
- Blog routes/feed/draft behavior are unchanged; smoke verified they still render/exclude correctly.

## Verification
- `pnpm lint`
- `pnpm exec vue-tsc --noEmit`
- `pnpm build`
- `git diff --check`
- Local `.output/server` smoke:
  - `/` contains recent writing, works preview, contact, miru/yomu, published post, and external links use `noopener noreferrer`.
  - `/blog` contains the published placeholder post and RSS link.
  - `/feed.xml` contains the published post and no draft hit.
  - `/blog/draft-example` returns `404`.
- Playwright screenshots captured for desktop, mobile, and dark home states.
