### PR TITLE
feat(works): implement Phase B works slice

### DIFF
--- a/app/components/works/WorksProjectList.vue
+++ b/app/components/works/WorksProjectList.vue
@@ -7,30 +7,34 @@ defineProps<{
 </script>
 
 <template>
-  <div class="home-work-list" aria-label="在做的项目">
+  <div class="works-project-list">
     <NuxtLink
       v-for="item in items"
       :key="item.key"
-      class="home-work-row"
+      class="works-project-row"
       :to="item.href"
       :external="item.external"
       :target="item.external ? '_blank' : undefined"
       :rel="item.external ? 'noopener noreferrer' : undefined"
     >
-      <span class="home-work-row__main">
-        <span class="home-work-row__name">
+      <span class="works-project-row__main">
+        <span class="works-project-row__name">
           {{ item.title }}
-          <span class="home-work-row__arrow" aria-hidden="true">↗</span>
+          <span class="works-project-row__arrow" aria-hidden="true">↗</span>
         </span>
-        <span class="home-work-row__description">
+        <span class="works-project-row__description">
           {{ item.description }}
         </span>
       </span>
 
-      <span class="home-work-row__side">
-        <span class="home-work-row__year">{{ item.year }}</span>
-        <span class="home-work-row__tags" aria-label="标签">
-          <span v-for="tag in item.tags" :key="tag" class="home-work-row__tag">
+      <span class="works-project-row__side">
+        <span class="works-project-row__year">{{ item.year }}</span>
+        <span class="works-project-row__tags" aria-label="标签">
+          <span
+            v-for="tag in item.tags"
+            :key="tag"
+            class="works-project-row__tag"
+          >
             {{ tag }}
           </span>
         </span>
@@ -40,11 +44,11 @@ defineProps<{
 </template>
 
 <style scoped>
-.home-work-list {
+.works-project-list {
   display: grid;
 }
 
-.home-work-row {
+.works-project-row {
   min-width: 0;
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
@@ -58,17 +62,17 @@ defineProps<{
   transition: var(--transition-interactive);
 }
 
-.home-work-row:last-child {
+.works-project-row:last-child {
   border-bottom: 1px solid var(--border-subtle);
 }
 
-.home-work-row__main {
+.works-project-row__main {
   min-width: 0;
   display: grid;
   gap: var(--spacing-2);
 }
 
-.home-work-row__name {
+.works-project-row__name {
   min-width: 0;
   color: var(--text-primary);
   font-family: var(--font-display);
@@ -79,41 +83,41 @@ defineProps<{
   transition: var(--transition-interactive);
 }
 
-.home-work-row__arrow {
+.works-project-row__arrow {
   display: inline-block;
   margin-inline-start: var(--spacing-1);
   color: var(--text-muted);
   transition: var(--transition-interactive);
 }
 
-.home-work-row__description {
+.works-project-row__description {
   max-width: 46ch;
   color: var(--text-muted);
   font-size: var(--text-base);
   line-height: var(--text-base--line-height);
 }
 
-.home-work-row__side {
+.works-project-row__side {
   display: grid;
   justify-items: end;
   gap: var(--spacing-3);
 }
 
-.home-work-row__year {
+.works-project-row__year {
   color: var(--text-muted);
   font-family: var(--font-mono);
   font-size: var(--text-xs);
   line-height: var(--text-xs--line-height);
 }
 
-.home-work-row__tags {
+.works-project-row__tags {
   display: flex;
   flex-wrap: wrap;
   justify-content: flex-end;
   gap: var(--spacing-2);
 }
 
-.home-work-row__tag {
+.works-project-row__tag {
   border: 1px solid var(--border-subtle);
   border-radius: var(--radius-control);
   padding: 0.125rem var(--spacing-2);
@@ -123,52 +127,52 @@ defineProps<{
   line-height: var(--text-xs--line-height);
 }
 
-.home-work-row:hover {
+.works-project-row:hover {
   padding-inline-start: var(--spacing-2);
 }
 
-.home-work-row:hover .home-work-row__name {
+.works-project-row:hover .works-project-row__name {
   color: var(--text-accent);
 }
 
-.home-work-row:hover .home-work-row__arrow {
+.works-project-row:hover .works-project-row__arrow {
   color: var(--text-accent);
   transform: translateX(4px);
 }
 
-.home-work-row:focus-visible {
+.works-project-row:focus-visible {
   outline: 2px solid var(--focus-ring-color);
   outline-offset: 3px;
   box-shadow: var(--focus-ring-shadow);
 }
 
 @media (max-width: 640px) {
-  .home-work-row {
+  .works-project-row {
     grid-template-columns: 1fr;
     gap: var(--spacing-3);
   }
 
-  .home-work-row__side {
+  .works-project-row__side {
     justify-items: start;
   }
 
-  .home-work-row__tags {
+  .works-project-row__tags {
     justify-content: flex-start;
   }
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .home-work-row,
-  .home-work-row__name,
-  .home-work-row__arrow {
+  .works-project-row,
+  .works-project-row__name,
+  .works-project-row__arrow {
     transition: none;
   }
 
-  .home-work-row:hover {
+  .works-project-row:hover {
     padding-inline-start: 0;
   }
 
-  .home-work-row:hover .home-work-row__arrow {
+  .works-project-row:hover .works-project-row__arrow {
     transform: none;
   }
 }

--- a/app/composables/useSiteContent.ts
+++ b/app/composables/useSiteContent.ts
@@ -21,6 +21,7 @@ export interface FeaturedWork {
   title: string
   href: string
   year: string
+  status: "active" | "published"
   description: string
   tags: string[]
   external?: boolean
@@ -58,6 +59,7 @@ export function useSiteContent() {
   const navItems = [
     { label: "首页", to: "/" },
     { label: "关于", to: "/about" },
+    { label: "作品", to: "/works" },
     { label: "文章", to: "/blog" },
   ]
 
@@ -68,7 +70,8 @@ export function useSiteContent() {
       title: "miru",
       href: "https://miru.ayingott.me",
       year: "2026",
-      description: "一个安静的 Markdown 阅读器,把排版和阅读状态放在第一位。",
+      status: "active",
+      description: "一个安静的 Markdown 阅读器，把排版和阅读状态放在第一位。",
       tags: ["reading", "pwa"],
       external: true,
     },
@@ -77,8 +80,31 @@ export function useSiteContent() {
       title: "yomu",
       href: "https://yomu.ayingott.me",
       year: "2026",
-      description: "每日发声阅读练习,用文章、领读和对照翻译建立语言节奏。",
+      status: "active",
+      description: "每日发声阅读练习，用文章、领读和对照翻译建立语言节奏。",
       tags: ["read aloud", "language"],
+      external: true,
+    },
+    {
+      key: "ayingott-theme",
+      title: "@ayingott/theme",
+      href: "https://design.ayingott.me",
+      year: "2026",
+      status: "published",
+      description:
+        "一套偏阅读体验的设计系统，把颜色、排版和交互 token 收束成可复用的基础。",
+      tags: ["design system", "tokens"],
+      external: true,
+    },
+    {
+      key: "fairy",
+      title: "fairy",
+      href: "https://github.com/LoTwT/fairy",
+      year: "2025",
+      status: "published",
+      description:
+        "ZZZ 伤害计算器与 AI plugin 实验，把角色面板、计算和验证流程整理成工具。",
+      tags: ["zzz", "calculator"],
       external: true,
     },
   ]

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -3,8 +3,8 @@ import { computed } from "vue"
 import HomeContactList from "~/components/home/HomeContactList.vue"
 import HomeHero from "~/components/home/HomeHero.vue"
 import HomeSection from "~/components/home/HomeSection.vue"
-import HomeWorkList from "~/components/home/HomeWorkList.vue"
 import HomeWritingList from "~/components/home/HomeWritingList.vue"
+import WorksProjectList from "~/components/works/WorksProjectList.vue"
 
 definePageMeta({
   layout: "home",
@@ -50,8 +50,10 @@ useSiteSeo({
         section-id="works-preview"
         label="在做的 · Works"
         title="在做的"
+        action-label="全部作品"
+        action-to="/works"
       >
-        <HomeWorkList :items="highlightedWorks" />
+        <WorksProjectList :items="highlightedWorks" />
       </HomeSection>
 
       <HomeSection section-id="elsewhere" label="联系 · Elsewhere" title="联系">

--- a/app/pages/works.vue
+++ b/app/pages/works.vue
@@ -1,0 +1,144 @@
+<script setup lang="ts">
+import WorksProjectList from "~/components/works/WorksProjectList.vue"
+
+const { featuredWorks } = useSiteContent()
+
+const activeWorks = computed(() =>
+  featuredWorks.filter((item) => item.status === "active"),
+)
+const publishedWorks = computed(() =>
+  featuredWorks.filter((item) => item.status === "published"),
+)
+
+useSiteSeo({
+  title: "作品 · ayingott.me",
+  ogTitle: "作品",
+  description: "Lo 正在做和已经发布的项目索引。",
+  path: "/works",
+})
+</script>
+
+<template>
+  <section class="works-page" aria-labelledby="works-title">
+    <header class="works-page__header">
+      <p class="works-page__kicker">作品 · Works</p>
+      <h1 id="works-title" class="works-page__title">作品</h1>
+      <p class="works-page__intro">
+        一些正在打磨或已经发布的项目。这里像索引一样保留入口，方便回到真实作品本身。
+      </p>
+    </header>
+
+    <div class="works-page__sections">
+      <section
+        v-if="activeWorks.length"
+        class="works-page__section"
+        aria-labelledby="active-works-title"
+      >
+        <h2 id="active-works-title" class="works-page__section-title">
+          在做的
+        </h2>
+        <WorksProjectList :items="activeWorks" />
+      </section>
+
+      <section
+        v-if="publishedWorks.length"
+        class="works-page__section"
+        aria-labelledby="published-works-title"
+      >
+        <h2 id="published-works-title" class="works-page__section-title">
+          已发布
+        </h2>
+        <WorksProjectList :items="publishedWorks" />
+      </section>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.works-page {
+  width: min(100%, 52rem);
+  margin-inline: auto;
+  display: grid;
+  gap: var(--spacing-10);
+}
+
+.works-page__header {
+  display: grid;
+}
+
+.works-page__kicker {
+  margin: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-3);
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  line-height: var(--text-xs--line-height);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.works-page__kicker::before {
+  content: "";
+  width: 1.4rem;
+  height: 2px;
+  flex: 0 0 auto;
+  background: var(--text-accent);
+  opacity: 0.85;
+}
+
+.works-page__title {
+  margin: var(--spacing-4) 0 0;
+  color: var(--text-primary);
+  font-family: var(--font-display);
+  font-size: var(--text-4xl);
+  line-height: var(--text-4xl--line-height);
+  font-weight: var(--font-weight-bold);
+  letter-spacing: var(--tracking-normal);
+}
+
+.works-page__intro {
+  max-width: var(--container-reading);
+  margin: var(--spacing-5) 0 0;
+  color: var(--text-muted);
+  font-size: var(--text-lg);
+  line-height: 1.8;
+}
+
+.works-page__sections {
+  display: grid;
+  gap: var(--spacing-10);
+}
+
+.works-page__section {
+  display: grid;
+  gap: var(--spacing-4);
+}
+
+.works-page__section-title {
+  margin: 0;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  line-height: var(--text-xs--line-height);
+  font-weight: var(--font-weight-normal);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+@media (max-width: 520px) {
+  .works-page {
+    gap: var(--spacing-8);
+  }
+
+  .works-page__title {
+    font-size: var(--text-3xl);
+    line-height: var(--text-3xl--line-height);
+  }
+
+  .works-page__intro {
+    font-size: var(--text-base);
+  }
+}
+</style>

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -80,7 +80,9 @@ function getBlogPrerenderRoutes() {
       return slug ? [`/blog/${slug}`] : []
     })
 
-  return Array.from(new Set(["/", "/about", "/blog", ...routes])).sort()
+  return Array.from(
+    new Set(["/", "/about", "/blog", "/works", ...routes]),
+  ).sort()
 }
 
 export default defineNuxtConfig({

--- a/server/routes/sitemap.xml.ts
+++ b/server/routes/sitemap.xml.ts
@@ -4,7 +4,7 @@ import { getBlogPostHref } from "~/utils/blog"
 import { escapeXml } from "~/utils/xml"
 
 const trailingSlashPattern = /\/+$/
-const staticRoutes = ["/", "/about", "/blog"]
+const staticRoutes = ["/", "/about", "/blog", "/works"]
 
 export default defineEventHandler(async (event) => {
   const config = useRuntimeConfig(event)


### PR DESCRIPTION
## Summary
- add the Phase B `/works` page with the editorial mono kicker, grouped active/published project rows, and the locked miru/yomu/@ayingott/theme/fairy project set
- add `作品` to the main nav, link the home works preview to `/works`, and reuse the shared project-list renderer across home and works
- prerender `/works` and include it in `/sitemap.xml`

## Verification
- `pnpm lint`
- `pnpm exec vue-tsc --noEmit`
- `pnpm generate`
- `pnpm build`
- `git diff --check`
- static smoke from `.output/public`: `/`, `/works/`, `/about/`, `/blog/`, `/blog/hello-phase-a/`, `/feed.xml`, `/sitemap.xml` = 200; `/blog/draft-example` = 404
- screenshot smoke for `/works/`: desktop, mobile 390px, and dark mode