### PR TITLE
fix(favicon): follow system color scheme

### DIFF
--- a/app/composables/useSiteFavicon.ts
+++ b/app/composables/useSiteFavicon.ts
@@ -1,71 +1,23 @@
-const faviconId = "site-favicon"
-const lightFaviconHref = "/lo.svg?v=light"
-const darkFaviconHref = "/lo-white.svg?v=dark"
-
-function createFaviconLink(href: string) {
-  const link = document.createElement("link")
-  link.id = faviconId
-  link.rel = "icon"
-  link.type = "image/svg+xml"
-  link.href = href
-  return link
-}
-
-function findFaviconLink() {
-  return (
-    document.querySelector<HTMLLinkElement>(`#${faviconId}`) ??
-    document.querySelector<HTMLLinkElement>(
-      'link[rel="icon"][type="image/svg+xml"]',
-    )
-  )
-}
+const lightFaviconHref = "/lo.svg"
+const darkFaviconHref = "/lo-white.svg"
 
 export function useSiteFavicon() {
-  const { isDark } = useAppliedColorMode()
-  const faviconHref = computed(() =>
-    isDark.value ? darkFaviconHref : lightFaviconHref,
-  )
-
   useHead({
     link: [
       {
-        key: faviconId,
-        id: faviconId,
+        key: "site-favicon-light",
         rel: "icon",
         type: "image/svg+xml",
-        href: () => faviconHref.value,
+        media: "(prefers-color-scheme: light)",
+        href: lightFaviconHref,
+      },
+      {
+        key: "site-favicon-dark",
+        rel: "icon",
+        type: "image/svg+xml",
+        media: "(prefers-color-scheme: dark)",
+        href: darkFaviconHref,
       },
     ],
   })
-
-  function syncFaviconLink() {
-    if (!import.meta.client) {
-      return
-    }
-
-    const href = faviconHref.value
-    const absoluteHref = new URL(href, window.location.href).href
-    const current = findFaviconLink()
-
-    if (!current) {
-      document.head.append(createFaviconLink(href))
-      return
-    }
-
-    if (current.href === absoluteHref && current.id === faviconId) {
-      return
-    }
-
-    const next = createFaviconLink(href)
-    current.replaceWith(next)
-  }
-
-  if (import.meta.client) {
-    watch(faviconHref, syncFaviconLink, {
-      flush: "post",
-      immediate: true,
-    })
-
-    onMounted(syncFaviconLink)
-  }
 }


### PR DESCRIPTION
## Summary
- decouple the browser tab favicon from the in-page color-mode toggle
- replace the client-side `isDark` favicon swap with static SVG icon links using `prefers-color-scheme` media queries
- reuse the existing `/lo.svg` and `/lo-white.svg` assets; no new external requests or assets

## Verification
- `pnpm lint`
- `pnpm exec vue-tsc --noEmit`
- `pnpm generate`
- `pnpm build`
- `git diff --check`
- generated HTML assertion: exactly two favicon links, `/lo.svg` with `(prefers-color-scheme: light)`, `/lo-white.svg` with `(prefers-color-scheme: dark)`, no dynamic fallback/swap link