### PR TITLE
feat(site): add contact link icons

### DIFF
--- a/app/components/home/HomeContactList.vue
+++ b/app/components/home/HomeContactList.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { ContactLink } from "~/composables/useSiteContent"
+import ContactLinkList from "~/components/site/ContactLinkList.vue"
 
 defineProps<{
   links: ContactLink[]
@@ -7,54 +8,5 @@ defineProps<{
 </script>
 
 <template>
-  <nav class="home-contact-list" aria-label="联系方式">
-    <NuxtLink
-      v-for="link in links"
-      :key="link.key"
-      class="home-contact-list__link"
-      :to="link.href"
-      :external="link.external"
-      :target="link.external ? '_blank' : undefined"
-      :rel="link.external ? 'noreferrer' : undefined"
-    >
-      {{ link.label }}
-    </NuxtLink>
-  </nav>
+  <ContactLinkList :links="links" variant="stacked" />
 </template>
-
-<style scoped>
-.home-contact-list {
-  display: flex;
-  flex-wrap: wrap;
-  gap: var(--spacing-3) var(--spacing-5);
-}
-
-.home-contact-list__link {
-  min-height: var(--touch-target-min);
-  display: inline-flex;
-  align-items: center;
-  border-radius: var(--radius-control);
-  color: var(--text-primary);
-  font-family: var(--font-mono);
-  font-size: var(--text-sm);
-  line-height: var(--text-sm--line-height);
-  text-decoration-color: color-mix(
-    in srgb,
-    var(--text-accent) 45%,
-    transparent
-  );
-  text-underline-offset: 0.28em;
-  transition: var(--transition-interactive);
-}
-
-.home-contact-list__link:hover {
-  color: var(--text-accent);
-  text-decoration-color: var(--text-accent);
-}
-
-.home-contact-list__link:focus-visible {
-  outline: 2px solid var(--focus-ring-color);
-  outline-offset: 2px;
-  box-shadow: var(--focus-ring-shadow);
-}
-</style>

--- a/app/components/site/ContactLinkList.vue
+++ b/app/components/site/ContactLinkList.vue
@@ -1,0 +1,111 @@
+<script setup lang="ts">
+import type { ContactLink } from "~/composables/useSiteContent"
+import SiteIcon from "~/components/site/SiteIcon.vue"
+
+withDefaults(
+  defineProps<{
+    links: ContactLink[]
+    ariaLabel?: string
+    variant?: "inline" | "stacked"
+  }>(),
+  {
+    ariaLabel: "联系方式",
+    variant: "inline",
+  },
+)
+</script>
+
+<template>
+  <nav
+    class="contact-link-list"
+    :class="`contact-link-list--${variant}`"
+    :aria-label="ariaLabel"
+  >
+    <template v-for="(link, index) in links" :key="link.key">
+      <span
+        v-if="variant === 'inline' && index > 0"
+        class="contact-link-list__separator"
+        aria-hidden="true"
+      >
+        ·
+      </span>
+      <NuxtLink
+        class="contact-link-list__link"
+        :to="link.href"
+        :external="link.external"
+        :target="link.external ? '_blank' : undefined"
+        :rel="link.external ? 'noopener noreferrer' : undefined"
+      >
+        <SiteIcon class="contact-link-list__icon" :name="link.icon" />
+        <span>{{ link.label }}</span>
+      </NuxtLink>
+    </template>
+  </nav>
+</template>
+
+<style scoped>
+.contact-link-list {
+  display: grid;
+  justify-items: start;
+}
+
+.contact-link-list--inline {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--spacing-2);
+}
+
+.contact-link-list--stacked {
+  gap: var(--spacing-2);
+}
+
+.contact-link-list__link {
+  min-height: var(--touch-target-min);
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-2);
+  border-radius: var(--radius-control);
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  line-height: var(--text-sm--line-height);
+  text-decoration-color: color-mix(
+    in srgb,
+    var(--text-accent) 45%,
+    transparent
+  );
+  text-underline-offset: 0.28em;
+  transition: var(--transition-interactive);
+}
+
+.contact-link-list__separator {
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  line-height: var(--text-sm--line-height);
+}
+
+.contact-link-list__link .contact-link-list__icon {
+  width: 1rem;
+  height: 1rem;
+  flex: 0 0 auto;
+  color: var(--text-muted);
+  transition: var(--transition-interactive);
+}
+
+.contact-link-list__link:hover {
+  color: var(--text-accent);
+  text-decoration-color: var(--text-accent);
+}
+
+.contact-link-list__link:hover .contact-link-list__icon {
+  color: var(--text-accent);
+}
+
+.contact-link-list__link:focus-visible {
+  outline: 2px solid var(--focus-ring-color);
+  outline-offset: 2px;
+  box-shadow: var(--focus-ring-shadow);
+}
+</style>

--- a/app/pages/about.vue
+++ b/app/pages/about.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import ContactLinkList from "~/components/site/ContactLinkList.vue"
+
 const { identity, nowText, contactLinks } = useSiteContent()
 
 const currentFocus = computed(
@@ -57,19 +59,7 @@ useSiteSeo({
 
         <div class="about-page__meta-group">
           <h2 class="about-page__meta-title">联系</h2>
-          <nav class="about-page__links" aria-label="联系方式">
-            <NuxtLink
-              v-for="link in contactLinks"
-              :key="link.key"
-              class="about-page__link"
-              :to="link.href"
-              :external="link.external"
-              :target="link.external ? '_blank' : undefined"
-              :rel="link.external ? 'noopener noreferrer' : undefined"
-            >
-              {{ link.label }}
-            </NuxtLink>
-          </nav>
+          <ContactLinkList :links="contactLinks" />
         </div>
       </aside>
     </div>
@@ -185,41 +175,6 @@ useSiteSeo({
   color: var(--text-primary);
   font-size: var(--text-sm);
   line-height: var(--text-sm--line-height);
-}
-
-.about-page__links {
-  display: flex;
-  flex-wrap: wrap;
-  gap: var(--spacing-3) var(--spacing-5);
-}
-
-.about-page__link {
-  min-height: var(--touch-target-min);
-  display: inline-flex;
-  align-items: center;
-  border-radius: var(--radius-control);
-  color: var(--text-primary);
-  font-family: var(--font-mono);
-  font-size: var(--text-sm);
-  line-height: var(--text-sm--line-height);
-  text-decoration-color: color-mix(
-    in srgb,
-    var(--text-accent) 45%,
-    transparent
-  );
-  text-underline-offset: 0.28em;
-  transition: var(--transition-interactive);
-}
-
-.about-page__link:hover {
-  color: var(--text-accent);
-  text-decoration-color: var(--text-accent);
-}
-
-.about-page__link:focus-visible {
-  outline: 2px solid var(--focus-ring-color);
-  outline-offset: 2px;
-  box-shadow: var(--focus-ring-shadow);
 }
 
 @media (max-width: 720px) {


### PR DESCRIPTION
## Summary
- add a shared `ContactLinkList` component that renders contact links with existing inline `SiteIcon` SVGs and visible text labels
- switch home contact links to stacked icon+text rows, and about colophon links to inline icon+text with aria-hidden separators
- preserve external link `target="_blank"` + `rel="noopener noreferrer"`, focus ring, and 44px touch targets without new dependencies or external requests

## Verification
- `pnpm lint`
- `pnpm exec vue-tsc --noEmit`
- `pnpm generate`
- `pnpm build`
- `git diff --cached --check`
- static contact output probe for home/about variants, icons, link attrs, and draft exclusion
- Playwright browser snapshots on generated output: home desktop stacked contact list; about 390px inline contact list with link names `GitHub`, `X`, `邮箱`

Build/generate only emitted the existing sourcemap warnings from Tailwind/module-preload.