### PR TITLE
fix(site): keep home contact links inline

### DIFF
--- a/app/components/home/HomeContactList.vue
+++ b/app/components/home/HomeContactList.vue
@@ -8,5 +8,5 @@ defineProps<{
 </script>
 
 <template>
-  <ContactLinkList :links="links" variant="stacked" />
+  <ContactLinkList :links="links" />
 </template>


### PR DESCRIPTION
## Summary
- keep the home contact links on one inline row by using the default inline `ContactLinkList` variant
- preserve the existing icon+text labels, aria-hidden separators, external link attrs, focus ring, and touch target behavior

## Verification
- `pnpm lint`
- `pnpm exec vue-tsc --noEmit`
- `pnpm generate`
- `git diff --check`
- static generated-output probe confirms home/about contact navs are inline and retain labels/icons/separators
- Playwright snapshots on generated output: desktop and 390px home contact list stay one row with accessible names `GitHub`, `X`, `邮箱`

Build warnings: only the existing Nuxt/Tailwind sourcemap warnings during generate.