### PR TITLE
feat(site): show selected works

### DIFF
--- a/app/components/works/WorksProjectList.vue
+++ b/app/components/works/WorksProjectList.vue
@@ -28,7 +28,6 @@ defineProps<{
       </span>
 
       <span class="works-project-row__side">
-        <span class="works-project-row__year">{{ item.year }}</span>
         <span class="works-project-row__tags" aria-label="标签">
           <span
             v-for="tag in item.tags"
@@ -100,14 +99,7 @@ defineProps<{
 .works-project-row__side {
   display: grid;
   justify-items: end;
-  gap: var(--spacing-3);
-}
-
-.works-project-row__year {
-  color: var(--text-muted);
-  font-family: var(--font-mono);
-  font-size: var(--text-xs);
-  line-height: var(--text-xs--line-height);
+  gap: var(--spacing-2);
 }
 
 .works-project-row__tags {

--- a/app/composables/useSiteContent.ts
+++ b/app/composables/useSiteContent.ts
@@ -20,7 +20,6 @@ export interface FeaturedWork {
   key: string
   title: string
   href: string
-  year: string
   status: "active" | "published"
   description: string
   tags: string[]
@@ -69,42 +68,18 @@ export function useSiteContent() {
       key: "miru",
       title: "miru",
       href: "https://miru.ayingott.me",
-      year: "2026",
       status: "active",
-      description: "一个安静的 Markdown 阅读器，把排版和阅读状态放在第一位。",
-      tags: ["reading", "pwa"],
-      external: true,
-    },
-    {
-      key: "yomu",
-      title: "yomu",
-      href: "https://yomu.ayingott.me",
-      year: "2026",
-      status: "active",
-      description: "每日发声阅读练习，用文章、领读和对照翻译建立语言节奏。",
-      tags: ["read aloud", "language"],
+      description: "A quiet, reading-first reader.",
+      tags: ["Reading"],
       external: true,
     },
     {
       key: "ayingott-theme",
-      title: "@ayingott/theme",
+      title: "Design system",
       href: "https://design.ayingott.me",
-      year: "2026",
       status: "published",
-      description:
-        "一套偏阅读体验的设计系统，把颜色、排版和交互 token 收束成可复用的基础。",
-      tags: ["design system", "tokens"],
-      external: true,
-    },
-    {
-      key: "fairy",
-      title: "fairy",
-      href: "https://github.com/LoTwT/fairy",
-      year: "2025",
-      status: "published",
-      description:
-        "ZZZ 伤害计算器与 AI plugin 实验，把角色面板、计算和验证流程整理成工具。",
-      tags: ["zzz", "calculator"],
+      description: "The design system this very site runs on.",
+      tags: ["Design · Tokens"],
       external: true,
     },
   ]

--- a/app/pages/about.vue
+++ b/app/pages/about.vue
@@ -4,7 +4,7 @@ import ContactLinkList from "~/components/site/ContactLinkList.vue"
 const { identity, nowText, contactLinks } = useSiteContent()
 
 const currentFocus = computed(
-  () => nowText.value || "打磨 miru / yomu / ayingott.me",
+  () => nowText.value || "打磨 miru / design system / ayingott.me",
 )
 
 const colophonGroups = computed(() => [


### PR DESCRIPTION
## Summary
- Narrow Phase B works content to the two approved entries: miru and Design system.
- Apply UX copy for the two editorial rows and remove yomu/fairy from the shared works source.
- Remove year display from works rows and align the About current-focus fallback with the selected works scope.

## Verification
- `pnpm install --frozen-lockfile`
- `git diff --check`
- `pnpm lint`
- `pnpm generate`
- Static output scan: `rg -n "yomu|fairy" app .output/public` returned no matches.
- Browser smoke against `python3 -m http.server 4178 --bind 127.0.0.1 --directory .output/public`:
  - `/` desktop: works preview has only miru + Design system, no yomu/fairy, no horizontal overflow.
  - `/works` desktop: two rows total, grouped as active miru and published Design system, no year text, correct external links.
  - `/works` 390px mobile: no horizontal overflow, row hit heights ~138px.
  - `/works` dark mode: `.dark` active, two rows, no yomu/fairy, no horizontal overflow.
  - `/about`: fallback current focus is `打磨 miru / design system / ayingott.me`, no yomu/fairy.
  - Browser console warnings/errors: 0.

## Screenshots
- Captured locally for handoff: `ayingott-task44-home-desktop.png`, `ayingott-task44-works-mobile.png`, `ayingott-task44-works-mobile-dark.png`.
