### PR TITLE
fix(blog): stabilize date formatting timezone

### DIFF
--- a/app/utils/blog.ts
+++ b/app/utils/blog.ts
@@ -13,6 +13,7 @@ const dateFormatter = new Intl.DateTimeFormat("zh-CN", {
   year: "numeric",
   month: "2-digit",
   day: "2-digit",
+  timeZone: "Asia/Shanghai",
 })
 const whitespacePattern = /\s+/g
 const cjkPattern = /[\u4E00-\u9FFF]/g

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "up": "taze latest -I -f",
     "prettier": "prettier --write .",
     "lint": "eslint .",
-    "nuxt": "nuxt"
+    "nuxt": "nuxt",
+    "verify:blog-date-timezone": "node scripts/verify-blog-date-timezone.mjs"
   },
   "dependencies": {
     "@ayingott/theme": "0.0.2",

--- a/scripts/verify-blog-date-timezone.mjs
+++ b/scripts/verify-blog-date-timezone.mjs
@@ -1,0 +1,31 @@
+import { execFileSync } from "node:child_process"
+import process from "node:process"
+
+const expected = "2026/05/25"
+const zones = ["UTC", "Asia/Shanghai"]
+
+for (const zone of zones) {
+  const output = execFileSync(
+    process.execPath,
+    [
+      "--experimental-strip-types",
+      "--input-type=module",
+      "-e",
+      "const { formatBlogDate } = await import('./app/utils/blog.ts'); console.log(formatBlogDate('2026-05-25'))",
+    ],
+    {
+      cwd: new URL("..", import.meta.url),
+      env: { ...process.env, TZ: zone },
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "inherit"],
+    },
+  ).trim()
+
+  if (output !== expected) {
+    throw new Error(
+      `formatBlogDate mismatch for TZ=${zone}: got ${output}, expected ${expected}`,
+    )
+  }
+
+  console.log(`TZ=${zone} ${output}`)
+}


### PR DESCRIPTION
## Summary
- pin blog date formatting to `Asia/Shanghai` so SSR and browser hydration render the same day
- add `pnpm verify:blog-date-timezone` to guard `formatBlogDate('2026-05-25')` under both `TZ=UTC` and `TZ=Asia/Shanghai`

## Root cause
`parseIsoDate()` intentionally parses `YYYY-MM-DD` as midnight `+08:00`, but `formatBlogDate()` used `Intl.DateTimeFormat` without an explicit `timeZone`. Cloudflare SSR can format that instant in UTC as the previous day, while the browser formats it in Asia/Shanghai, producing a Nuxt hydration mismatch.

## Verification
- `pnpm verify:blog-date-timezone`
- `pnpm lint`
- `pnpm generate`
- `git diff --check`
- local generated preview smoke on `/`, `/blog/`, `/blog/hello-phase-a/`: no hydration warnings after navigation; blog list/detail show `2026/05/25`
